### PR TITLE
Change default keybind

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,5 @@
 [
-  { "keys": ["ctrl+h"], "command": "dash_doc"},
+  { "keys": ["ctrl+command+h"], "command": "dash_doc"},
   { "keys": ["ctrl+alt+h"], "command": "dash_doc",
                             "args": { "syntax_sensitive": "true" } }
 ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ DashDoc provides integration of [Dash][1] into Sublime Text.
 
 ## Usage
 
-You can look up the word under the cursor or selected text in Dash using `Ctrl+h`.
+You can look up the word under the cursor or selected text in Dash using `Ctrl+Command+h`.
 
 ## Options
 


### PR DESCRIPTION
`ctrl+h` is often used as a backspace in many OSX applications.
I think it may be better to bind another key combination as a default.
