### PR TITLE
fix Syntax sensitivity when current syntax is Ruby on Rails

### DIFF
--- a/DashDoc.sublime-settings
+++ b/DashDoc.sublime-settings
@@ -20,7 +20,7 @@
     "Perl"              : "perl",
     "PHP"               : "php",
     "Python"            : "python2",
-    "Rails"             : "rails",
+    "Ruby on Rails"     : "rails",
     "Ruby"              : "ruby",
     "Scala"             : "scala",
     "Shell-Unix-Generic": "manpages",


### PR DESCRIPTION
 Try running the following command in show panel(ctrl+backquote)

```
>>> import sublime
>>> import sublime_plugin
>>> import os
>>> import subprocess
>>> syntax = os.path.basename(view.settings().get('syntax'))
>>> syntax = os.path.splitext(syntax)[0]
>>> syntax
u'Ruby on Rails'
```
