### PR TITLE
Add sublime_text version selectors

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5,10 +5,9 @@
             "name": "DashDoc",
             "description": "Open the selected text or text under cursor in Dash documentation browser",
             "details": "https://github.com/farcaller/DashDoc",
-            "issues": "https://github.com/farcaller/DashDoc/issues",
-            "donate": "https://www.gittip.com/farcaller/",
             "releases": [
                 {
+                    "sublime_text": "*",
                     "platforms": ["osx"],
                     "details": "https://github.com/farcaller/DashDoc/tags"
                 }


### PR DESCRIPTION
We require these now due to the confusion it caused in the past

Also removed redundant information because Package Control defaults to these anyway
