### PR TITLE
Remap DashDoc keybindings (to avoid OS X Delete conflict)

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,5 @@
 [
-  { "keys": ["ctrl+h"], "command": "dash_doc"},
-  { "keys": ["ctrl+alt+h"], "command": "dash_doc",
+  { "keys": ["super+ctrl+h"], "command": "dash_doc"},
+  { "keys": ["super+shift+h"], "command": "dash_doc",
                             "args": { "flip_syntax_sensitive": true } }
 ]


### PR DESCRIPTION
In OS X, Ctrl+h is mapped to Delete as part of the universal Emacs keybindings. This PR has new keybindings – that at the very least don’t conflict with any OSX or ST2 keybindings – that I use to maintain the Delete key while trying not making invoking DashDoc require some finger gymnastics.
