### PR TITLE
Windows support

### DIFF
--- a/DashDoc.py
+++ b/DashDoc.py
@@ -52,9 +52,13 @@ class DashDocCommand(sublime_plugin.TextCommand):
         keys = docset_keys(self.view, syntax_docset_map) if syntax_sensitive else []
 
         if platform.system() == 'Windows':
-            subprocess.call(['start',
-                         'dash-plugin://keys=%s&query=%s' % (','.join(keys), quote(query))],
-                         shell=True)
+            # sending keys=<nothing> confuses some Windows doc viewers
+            if keys:
+                # ampersand must be escaped and ^ is the Windows shell escape char
+                url = 'dash-plugin://keys=%s^&query=%s' % (','.join(keys), quote(query))
+            else:
+                url = 'dash-plugin://query=%s' % quote(query)
+            subprocess.call(['start', url], shell=True)
         else:
             subprocess.call(['/usr/bin/open', '-g',
                          'dash-plugin://keys=%s&query=%s' % (','.join(keys), quote(query))])

--- a/DashDoc.py
+++ b/DashDoc.py
@@ -2,6 +2,7 @@ import sublime, sublime_plugin
 
 import os
 import subprocess
+import platform
 
 try:
     from urllib import quote         # Python 2
@@ -50,5 +51,10 @@ class DashDocCommand(sublime_plugin.TextCommand):
         syntax_sensitive = flip_syntax_sensitive ^ syntax_sensitive_as_default
         keys = docset_keys(self.view, syntax_docset_map) if syntax_sensitive else []
 
-        subprocess.call(['/usr/bin/open', '-g',
+        if platform.system() == 'Windows':
+            subprocess.call(['start',
+                         'dash-plugin://keys=%s&query=%s' % (','.join(keys), quote(query))],
+                         shell=True)
+        else:
+            subprocess.call(['/usr/bin/open', '-g',
                          'dash-plugin://keys=%s&query=%s' % (','.join(keys), quote(query))])

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,0 +1,5 @@
+[
+  { "keys": ["ctrl+h"], "command": "dash_doc"},
+  { "keys": ["ctrl+alt+h"], "command": "dash_doc",
+                            "args": { "flip_syntax_sensitive": true } }
+]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -43,6 +43,22 @@
                   "platform": "OSX"
                 },
                 "caption": "Key Bindings - User"
+              },
+              {
+                "command": "open_file", "args":
+                {
+                  "file": "${packages}/DashDoc/Default (Windows).sublime-keymap",
+                  "platform": "Windows"
+                },
+                "caption": "Key Bindings - Default"
+              },
+              {
+                "command": "open_file", "args":
+                {
+                  "file": "${packages}/User/Default (Windows).sublime-keymap",
+                  "platform": "Windows"
+                },
+                "caption": "Key Bindings - User"
               }
             ]
           }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-DashDoc provides integration of [Dash][1] into Sublime Text.
+DashDoc provides integration of [Dash][1] (on OS X) and [Zeal][7] or [Velocity][8] (on Windows) into Sublime Text.
 
 ## If the package is not available in the install list
 
-You need to be on OS X to use DashDoc. You might have installed it already. If nothing helps, please check package control [troubleshooting](https://packagecontrol.io/docs/troubleshooting) page or fill a bug against [package control](https://packagecontrol.io/docs/issues).
+You need to be on OS X or Windows to use DashDoc. You might have installed it already. If nothing helps, please check package control [troubleshooting](https://packagecontrol.io/docs/troubleshooting) page or fill a bug against [package control](https://packagecontrol.io/docs/issues).
 
 ## Usage
 
@@ -105,4 +105,5 @@ More information on [Dash docsets][2].
 [4]: http://farcaller.net/
 [5]: http://db.inf.uni-tuebingen.de/team/grust/
 [6]: https://packagecontrol.io/installation
-
+[7]: https://zealdocs.org/
+[8]: https://velocity.silverlakesoftware.com/

--- a/messages/1.6.0.txt
+++ b/messages/1.6.0.txt
@@ -1,0 +1,3 @@
+This version adds support for Windows, when using Dash-compatible viewers. It
+has been tested against Zeal (https://zealdocs.org/) and Velocity
+(https://velocity.silverlakesoftware.com/).

--- a/packages.json
+++ b/packages.json
@@ -8,7 +8,7 @@
             "releases": [
                 {
                     "sublime_text": "*",
-                    "platforms": ["osx"],
+                    "platforms": ["osx", "windows"],
                     "details": "https://github.com/farcaller/DashDoc/tags"
                 }
             ]


### PR DESCRIPTION
Adds support for Windows, to work with Dash-compatible doc viewers on that platform. This is tested against the two most popular (only?) Dash-compatible Windows viewers, [Zeal](https://zealdocs.org/) and [Velocity](https://velocity.silverlakesoftware.com/).