### PR TITLE
Added support for running a Dash search in the background

### DIFF
--- a/DashDoc.py
+++ b/DashDoc.py
@@ -26,7 +26,7 @@ def docset_keys(view, syntax_docset_map):
 
 
 class DashDocCommand(sublime_plugin.TextCommand):
-    def run(self, edit, flip_syntax_sensitive=False):
+    def run(self, edit, flip_syntax_sensitive=False, run_in_background=False):
         # read global and (project-specific) local settings
         global_settings = sublime.load_settings('DashDoc.sublime-settings')
         settings  = self.view.settings()
@@ -51,14 +51,17 @@ class DashDocCommand(sublime_plugin.TextCommand):
         syntax_sensitive = flip_syntax_sensitive ^ syntax_sensitive_as_default
         keys = docset_keys(self.view, syntax_docset_map) if syntax_sensitive else []
 
+        # background
+        background_string = '&prevent_activation=true' if run_in_background else ''
+
         if platform.system() == 'Windows':
             # sending keys=<nothing> confuses some Windows doc viewers
             if keys:
                 # ampersand must be escaped and ^ is the Windows shell escape char
-                url = 'dash-plugin://keys=%s^&query=%s' % (','.join(keys), quote(query))
+                url = 'dash-plugin://keys=%s^&query=%s%s' % (','.join(keys), quote(query), background_string)
             else:
-                url = 'dash-plugin://query=%s' % quote(query)
+                url = 'dash-plugin://query=%s%s' % (quote(query), background_string)
             subprocess.call(['start', url], shell=True)
         else:
             subprocess.call(['/usr/bin/open', '-g',
-                         'dash-plugin://keys=%s&query=%s' % (','.join(keys), quote(query))])
+                         'dash-plugin://keys=%s&query=%s%s' % (','.join(keys), quote(query), background_string)])

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,13 +1,32 @@
 [
     {
         "caption": "DashDoc: invoke Dash with selected word",
-        "command": "dash_doc"
+        "command": "dash_doc",
+        "args": {
+            "flip_syntax_sensitive": false
+        }
     },
     {
         "caption": "DashDoc: invoke Dash with selected word (flip syntax sensitivity)",
         "command": "dash_doc",
         "args": {
             "flip_syntax_sensitive": true
+        }
+    },
+    {
+        "caption": "DashDoc: invoke Dash in background with selected word",
+        "command": "dash_doc",
+        "args": {
+            "flip_syntax_sensitive": false,
+            "run_in_background": true
+        }
+    },
+    {
+        "caption": "DashDoc: invoke Dash in background with selected word (flip syntax sensitivity)",
+        "command": "dash_doc",
+        "args": {
+            "flip_syntax_sensitive": true,
+            "run_in_background": true
         }
     }
 ]


### PR DESCRIPTION
These changes add support for running a Dash search in the background, without switching to Dash as the active application, keeping the focus on Sublime Text. This is useful when you're using a dual-monitor setup, or even just multiple windows side by side on a single screen, and you'd like to search while keeping your keyboard focus in the editor. 

Key bindings can be set up for the regular search and then the background search like this:

```
	{ "keys": ["YOUR HOTKEY"], "command": "dash_doc"},
	{ "keys": ["YOUR HOTKEY"], "command": "dash_doc",
                               "args": { "flip_syntax_sensitive": true } },
	{ "keys": ["YOUR HOTKEY"], "command": "dash_doc",
                               "args": { "run_in_background": true } },
        { "keys": ["YOUR HOTKEY"], "command": "dash_doc",
                               "args": { "flip_syntax_sensitive": true,
                               		 "run_in_background": true } }
```
