### PR TITLE
fixing KDE Plasma 5 URL handling

### DIFF
--- a/DashDoc.py
+++ b/DashDoc.py
@@ -64,7 +64,7 @@ class DashDocCommand(sublime_plugin.TextCommand):
             subprocess.call(['start', url], shell=True)
         elif platform.system() == 'Linux':
             subprocess.call(['/usr/bin/xdg-open',
-                         'dash-plugin://keys=%s&query=%s%s' % (','.join(keys), quote(query), background_string)])
+                         'dash-plugin:keys=%s&query=%s%s' % (','.join(keys), quote(query), background_string)])
         else:
             subprocess.call(['/usr/bin/open', '-g',
-                         'dash-plugin://keys=%s&query=%s%s' % (','.join(keys), quote(query), background_string)])
+                         'dash-plugin:keys=%s&query=%s%s' % (','.join(keys), quote(query), background_string)])


### PR DESCRIPTION
noticed dash-doc did not have proper URL handling on my KDE Plasma Linux DE... after some investigation, I found a similar issue on zeal docs here: 

https://github.com/zealdocs/zeal/issues/471

where the zeal docs author suggested getting rid of the `//` after `dash-plugin://` and all was well.

I tested this by making this modification on my system, and zeal is called up properly.  I am unable to test other linux distributions though. 