### PR TITLE
Fixing a syntax error

### DIFF
--- a/DashDoc.py
+++ b/DashDoc.py
@@ -25,7 +25,7 @@ def docset_keys(view, syntax_docset_map):
         return []
 
 
-def open_dash(query, keys, run_in_background)
+def open_dash(query, keys, run_in_background):
     # background
     background_string = '&prevent_activation=true' if run_in_background else ''
 


### PR DESCRIPTION
Fixes the syntax error introduced by https://github.com/farcaller/DashDoc/pull/67

The error logs:
```
reloading plugin DashDoc.DashDoc
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 125, in reload_plugin
    m = importlib.import_module(modulename)
  File "./python3.3/importlib/__init__.py", line 90, in import_module
  File "<frozen importlib._bootstrap>", line 1584, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1565, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1532, in _find_and_load_unlocked
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 1199, in load_module
    exec(compile(source, source_path, 'exec'), mod.__dict__)
  File "/Users/jacek/Library/Application Support/Sublime Text 3/Installed Packages/DashDoc.sublime-package/DashDoc.py", line 28
    def open_dash(query, keys, run_in_background)
                                                ^
SyntaxError: invalid syntax
```